### PR TITLE
bugfix: cleanup event listeners

### DIFF
--- a/es6/DnR.js
+++ b/es6/DnR.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaultTheme = undefined;
+exports.defaultTheme = exports.disableSelect = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -26,6 +26,14 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var disableSelect = exports.disableSelect = {
+  userSelect: 'none',
+  WebkitUserSelect: 'none',
+  msUserSelect: 'none',
+  MozUserSelect: 'none',
+  OUserSelect: 'none'
+};
 
 var defaultTheme = exports.defaultTheme = {
   title: {
@@ -63,7 +71,7 @@ var DnR = function (_React$Component) {
   function DnR(props) {
     _classCallCheck(this, DnR);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(DnR).call(this, props));
+    var _this = _possibleConstructorReturn(this, (DnR.__proto__ || Object.getPrototypeOf(DnR)).call(this, props));
 
     var _this$props = _this.props;
     var transition = _this$props.transition;
@@ -78,6 +86,9 @@ var DnR = function (_React$Component) {
       cursor: 'auto',
       transition: prefixedTransition(transition ? transition : theme.transition)
     };
+
+    _this.mouseMoveListener = _this._onMove.bind(_this);
+    _this.mouseUpListener = _this._onUp.bind(_this);
     return _this;
   }
 
@@ -98,8 +109,8 @@ var DnR = function (_React$Component) {
       this.frameRect.top = initialTop || this.refs.frame.offsetTop;
       this.frameRect.left = initialLeft || this.refs.frame.offsetLeft;
 
-      this.mouseMoveListener = attachedTo.addEventListener('mousemove', this._onMove.bind(this));
-      this.mouseUpListener = attachedTo.addEventListener('mouseup', this._onUp.bind(this));
+      attachedTo.addEventListener('mousemove', this.mouseMoveListener);
+      attachedTo.addEventListener('mouseup', this.mouseUpListener);
     }
   }, {
     key: "componentWillReceiveProps",
@@ -112,13 +123,13 @@ var DnR = function (_React$Component) {
     key: "componentWillUnmount",
     value: function componentWillUnmount() {
       this.props.attachedTo.removeEventListener('mousemove', this.mouseMoveListener);
-      this.props.attachedTo.removeEventListener('mousemove', this.mouseUpListener);
+      this.props.attachedTo.removeEventListener('mouseup', this.mouseUpListener);
     }
   }, {
     key: "transform",
     value: function transform(state) {
-      var allowTransition = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
-      var updateHistory = arguments.length <= 2 || arguments[2] === undefined ? true : arguments[2];
+      var allowTransition = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+      var updateHistory = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
 
       var boundingBox = this.getFrameRect();
 
@@ -152,21 +163,21 @@ var DnR = function (_React$Component) {
   }, {
     key: "restore",
     value: function restore() {
-      var allowTransition = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+      var allowTransition = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
       this.transform(this.prevState, allowTransition);
     }
   }, {
     key: "minimize",
     value: function minimize() {
-      var allowTransition = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+      var allowTransition = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
       this.transform({ width: 0, height: 0 }, allowTransition);
     }
   }, {
     key: "maximize",
     value: function maximize() {
-      var allowTransition = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+      var allowTransition = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
       this.transform({ top: 0, left: 0, width: this.props.attachedTo.innerWidth, height: this.props.attachedTo.innerHeight }, allowTransition);
     }
@@ -251,15 +262,6 @@ var DnR = function (_React$Component) {
         }
       }
 
-      var titleBar = _react2.default.createElement(
-        "div",
-        { ref: "title",
-          style: _extends({}, theme.title, titleStyle) },
-        this.props.titleBar
-      );
-
-      var frameTransition = animate && this.allowTransition ? this.state.transition : {};
-
       var cursor = this.state.cursor;
 
       if (cursorRemap) {
@@ -267,6 +269,28 @@ var DnR = function (_React$Component) {
 
         if (res && typeof res === 'string') cursor = res;
       }
+
+      var dnrState = {
+        cursor: cursor,
+        clicked: this.clicked,
+        frameRect: this.frameRect,
+        allowTransition: this.allowTransition
+      };
+
+      var titleBar = _react2.default.createElement(
+        "div",
+        { ref: "title",
+          style: _extends({}, theme.title, titleStyle, {
+            cursor: cursor
+          }) },
+        typeof this.props.titleBar !== 'string' ? _react2.default.cloneElement(this.props.titleBar, { dnrState: dnrState }) : this.props.titleBar
+      );
+
+      var childrenWithProps = _react2.default.Children.map(children, function (child) {
+        return typeof child === 'string' ? child : _react2.default.cloneElement(child, { dnrState: dnrState });
+      });
+
+      var frameTransition = animate && this.allowTransition ? this.state.transition : {};
 
       if (onMove && (pervFrameRect.top !== this.frameRect.top || pervFrameRect.left !== this.frameRect.left)) {
         setTimeout(onMove.bind(this, this.frameRect, pervFrameRect));
@@ -287,7 +311,7 @@ var DnR = function (_React$Component) {
           },
           style: _extends({}, theme.frame, frameTransition, {
             cursor: cursor
-          }, style, this.frameRect)
+          }, style, this.frameRect, this.clicked ? disableSelect : {})
         }, other),
         titleBar,
         _react2.default.createElement(
@@ -295,7 +319,7 @@ var DnR = function (_React$Component) {
           { ref: "content",
             className: "contentClassName",
             style: _extends({ position: 'absolute', width: '100%', top: theme.title.height, bottom: 0 }, contentStyle) },
-          children
+          childrenWithProps
         )
       );
     }

--- a/es6/shadow.js
+++ b/es6/shadow.js
@@ -34,7 +34,7 @@ var Shadow = function (_React$Component) {
   function Shadow() {
     _classCallCheck(this, Shadow);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(Shadow).apply(this, arguments));
+    return _possibleConstructorReturn(this, (Shadow.__proto__ || Object.getPrototypeOf(Shadow)).apply(this, arguments));
   }
 
   _createClass(Shadow, [{

--- a/es6/themes.js
+++ b/es6/themes.js
@@ -31,7 +31,7 @@ var Button = exports.Button = function (_React$Component) {
 	function Button(props) {
 		_classCallCheck(this, Button);
 
-		var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Button).call(this, props));
+		var _this = _possibleConstructorReturn(this, (Button.__proto__ || Object.getPrototypeOf(Button)).call(this, props));
 
 		_this.state = {
 			hover: false,
@@ -50,10 +50,16 @@ var Button = exports.Button = function (_React$Component) {
 			var hoverStyle = _props.hoverStyle;
 			var downStyle = _props.downStyle;
 			var children = _props.children;
+			var cursor = _props.cursor;
 
-			var other = _objectWithoutProperties(_props, ['style', 'hoverStyle', 'downStyle', 'children']);
+			var other = _objectWithoutProperties(_props, ['style', 'hoverStyle', 'downStyle', 'children', 'cursor']);
 
-			var buttonStyle = _extends({}, style, this.state.hover ? hoverStyle : {}, this.state.down ? downStyle : {});
+			var dragging = /resize$/.test(cursor);
+
+			var buttonStyle = _extends({}, style, this.state.hover && !dragging ? hoverStyle : {}, this.state.down && !dragging ? downStyle : {}, {
+				cursor: cursor
+			});
+
 			return _react2.default.createElement(
 				'button',
 				_extends({
@@ -88,8 +94,9 @@ var TitleBar = exports.TitleBar = function TitleBar(_ref) {
 	var button1Children = _ref.button1Children;
 	var button2Children = _ref.button2Children;
 	var button3Children = _ref.button3Children;
+	var dnrState = _ref.dnrState;
 
-	var other = _objectWithoutProperties(_ref, ['children', 'buttons', 'button1', 'button2', 'button3', 'button1Children', 'button2Children', 'button3Children']);
+	var other = _objectWithoutProperties(_ref, ['children', 'buttons', 'button1', 'button2', 'button3', 'button1Children', 'button2Children', 'button3Children', 'dnrState']);
 
 	return _react2.default.createElement(
 		'div',
@@ -99,17 +106,17 @@ var TitleBar = exports.TitleBar = function TitleBar(_ref) {
 			buttons,
 			_react2.default.createElement(
 				Button,
-				button1,
+				_extends({}, button1, { cursor: dnrState.cursor }),
 				button1Children
 			),
 			_react2.default.createElement(
 				Button,
-				button2,
+				_extends({}, button2, { cursor: dnrState.cursor }),
 				button2Children
 			),
 			_react2.default.createElement(
 				Button,
-				button3,
+				_extends({}, button3, { cursor: dnrState.cursor }),
 				button3Children
 			)
 		),
@@ -331,9 +338,9 @@ var WindowsTheme = exports.WindowsTheme = function WindowsTheme(_ref3) {
 				button1: minimizeButton,
 				button2: maximizeButton,
 				button3: closeButton,
-				button1Children: '‒',
-				button2Children: '□',
-				button3Children: '˟' },
+				button1Children: '\u2012',
+				button2Children: '\u25A1',
+				button3Children: '\u02DF' },
 			_react2.default.createElement(
 				'div',
 				{ style: {

--- a/lib/DnR.js
+++ b/lib/DnR.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.defaultTheme = undefined;
+exports.defaultTheme = exports.disableSelect = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -26,6 +26,14 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var disableSelect = exports.disableSelect = {
+  userSelect: 'none',
+  WebkitUserSelect: 'none',
+  msUserSelect: 'none',
+  MozUserSelect: 'none',
+  OUserSelect: 'none'
+};
 
 var defaultTheme = exports.defaultTheme = {
   title: {
@@ -63,7 +71,7 @@ var DnR = function (_React$Component) {
   function DnR(props) {
     _classCallCheck(this, DnR);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(DnR).call(this, props));
+    var _this = _possibleConstructorReturn(this, (DnR.__proto__ || Object.getPrototypeOf(DnR)).call(this, props));
 
     var _this$props = _this.props;
     var transition = _this$props.transition;
@@ -78,6 +86,9 @@ var DnR = function (_React$Component) {
       cursor: 'auto',
       transition: prefixedTransition(transition ? transition : theme.transition)
     };
+
+    _this.mouseMoveListener = _this._onMove.bind(_this);
+    _this.mouseUpListener = _this._onUp.bind(_this);
     return _this;
   }
 
@@ -98,8 +109,8 @@ var DnR = function (_React$Component) {
       this.frameRect.top = initialTop || this.refs.frame.offsetTop;
       this.frameRect.left = initialLeft || this.refs.frame.offsetLeft;
 
-      this.mouseMoveListener = attachedTo.addEventListener('mousemove', this._onMove.bind(this));
-      this.mouseUpListener = attachedTo.addEventListener('mouseup', this._onUp.bind(this));
+      attachedTo.addEventListener('mousemove', this.mouseMoveListener);
+      attachedTo.addEventListener('mouseup', this.mouseUpListener);
     }
   }, {
     key: "componentWillReceiveProps",
@@ -112,13 +123,13 @@ var DnR = function (_React$Component) {
     key: "componentWillUnmount",
     value: function componentWillUnmount() {
       this.props.attachedTo.removeEventListener('mousemove', this.mouseMoveListener);
-      this.props.attachedTo.removeEventListener('mousemove', this.mouseUpListener);
+      this.props.attachedTo.removeEventListener('mouseup', this.mouseUpListener);
     }
   }, {
     key: "transform",
     value: function transform(state) {
-      var allowTransition = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
-      var updateHistory = arguments.length <= 2 || arguments[2] === undefined ? true : arguments[2];
+      var allowTransition = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+      var updateHistory = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
 
       var boundingBox = this.getFrameRect();
 
@@ -152,21 +163,21 @@ var DnR = function (_React$Component) {
   }, {
     key: "restore",
     value: function restore() {
-      var allowTransition = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+      var allowTransition = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
       this.transform(this.prevState, allowTransition);
     }
   }, {
     key: "minimize",
     value: function minimize() {
-      var allowTransition = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+      var allowTransition = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
       this.transform({ width: 0, height: 0 }, allowTransition);
     }
   }, {
     key: "maximize",
     value: function maximize() {
-      var allowTransition = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+      var allowTransition = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
       this.transform({ top: 0, left: 0, width: this.props.attachedTo.innerWidth, height: this.props.attachedTo.innerHeight }, allowTransition);
     }
@@ -251,15 +262,6 @@ var DnR = function (_React$Component) {
         }
       }
 
-      var titleBar = _react2.default.createElement(
-        "div",
-        { ref: "title",
-          style: _extends({}, theme.title, titleStyle) },
-        this.props.titleBar
-      );
-
-      var frameTransition = animate && this.allowTransition ? this.state.transition : {};
-
       var cursor = this.state.cursor;
 
       if (cursorRemap) {
@@ -267,6 +269,28 @@ var DnR = function (_React$Component) {
 
         if (res && typeof res === 'string') cursor = res;
       }
+
+      var dnrState = {
+        cursor: cursor,
+        clicked: this.clicked,
+        frameRect: this.frameRect,
+        allowTransition: this.allowTransition
+      };
+
+      var titleBar = _react2.default.createElement(
+        "div",
+        { ref: "title",
+          style: _extends({}, theme.title, titleStyle, {
+            cursor: cursor
+          }) },
+        typeof this.props.titleBar !== 'string' ? _react2.default.cloneElement(this.props.titleBar, { dnrState: dnrState }) : this.props.titleBar
+      );
+
+      var childrenWithProps = _react2.default.Children.map(children, function (child) {
+        return typeof child === 'string' ? child : _react2.default.cloneElement(child, { dnrState: dnrState });
+      });
+
+      var frameTransition = animate && this.allowTransition ? this.state.transition : {};
 
       if (onMove && (pervFrameRect.top !== this.frameRect.top || pervFrameRect.left !== this.frameRect.left)) {
         setTimeout(onMove.bind(this, this.frameRect, pervFrameRect));
@@ -287,7 +311,7 @@ var DnR = function (_React$Component) {
           },
           style: _extends({}, theme.frame, frameTransition, {
             cursor: cursor
-          }, style, this.frameRect)
+          }, style, this.frameRect, this.clicked ? disableSelect : {})
         }, other),
         titleBar,
         _react2.default.createElement(
@@ -295,7 +319,7 @@ var DnR = function (_React$Component) {
           { ref: "content",
             className: "contentClassName",
             style: _extends({ position: 'absolute', width: '100%', top: theme.title.height, bottom: 0 }, contentStyle) },
-          children
+          childrenWithProps
         )
       );
     }

--- a/lib/shadow.js
+++ b/lib/shadow.js
@@ -34,7 +34,7 @@ var Shadow = function (_React$Component) {
   function Shadow() {
     _classCallCheck(this, Shadow);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(Shadow).apply(this, arguments));
+    return _possibleConstructorReturn(this, (Shadow.__proto__ || Object.getPrototypeOf(Shadow)).apply(this, arguments));
   }
 
   _createClass(Shadow, [{

--- a/lib/themes.js
+++ b/lib/themes.js
@@ -31,7 +31,7 @@ var Button = exports.Button = function (_React$Component) {
 	function Button(props) {
 		_classCallCheck(this, Button);
 
-		var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Button).call(this, props));
+		var _this = _possibleConstructorReturn(this, (Button.__proto__ || Object.getPrototypeOf(Button)).call(this, props));
 
 		_this.state = {
 			hover: false,
@@ -50,10 +50,16 @@ var Button = exports.Button = function (_React$Component) {
 			var hoverStyle = _props.hoverStyle;
 			var downStyle = _props.downStyle;
 			var children = _props.children;
+			var cursor = _props.cursor;
 
-			var other = _objectWithoutProperties(_props, ['style', 'hoverStyle', 'downStyle', 'children']);
+			var other = _objectWithoutProperties(_props, ['style', 'hoverStyle', 'downStyle', 'children', 'cursor']);
 
-			var buttonStyle = _extends({}, style, this.state.hover ? hoverStyle : {}, this.state.down ? downStyle : {});
+			var dragging = /resize$/.test(cursor);
+
+			var buttonStyle = _extends({}, style, this.state.hover && !dragging ? hoverStyle : {}, this.state.down && !dragging ? downStyle : {}, {
+				cursor: cursor
+			});
+
 			return _react2.default.createElement(
 				'button',
 				_extends({
@@ -88,8 +94,9 @@ var TitleBar = exports.TitleBar = function TitleBar(_ref) {
 	var button1Children = _ref.button1Children;
 	var button2Children = _ref.button2Children;
 	var button3Children = _ref.button3Children;
+	var dnrState = _ref.dnrState;
 
-	var other = _objectWithoutProperties(_ref, ['children', 'buttons', 'button1', 'button2', 'button3', 'button1Children', 'button2Children', 'button3Children']);
+	var other = _objectWithoutProperties(_ref, ['children', 'buttons', 'button1', 'button2', 'button3', 'button1Children', 'button2Children', 'button3Children', 'dnrState']);
 
 	return _react2.default.createElement(
 		'div',
@@ -99,17 +106,17 @@ var TitleBar = exports.TitleBar = function TitleBar(_ref) {
 			buttons,
 			_react2.default.createElement(
 				Button,
-				button1,
+				_extends({}, button1, { cursor: dnrState.cursor }),
 				button1Children
 			),
 			_react2.default.createElement(
 				Button,
-				button2,
+				_extends({}, button2, { cursor: dnrState.cursor }),
 				button2Children
 			),
 			_react2.default.createElement(
 				Button,
-				button3,
+				_extends({}, button3, { cursor: dnrState.cursor }),
 				button3Children
 			)
 		),
@@ -331,9 +338,9 @@ var WindowsTheme = exports.WindowsTheme = function WindowsTheme(_ref3) {
 				button1: minimizeButton,
 				button2: maximizeButton,
 				button3: closeButton,
-				button1Children: '‒',
-				button2Children: '□',
-				button3Children: '˟' },
+				button1Children: '\u2012',
+				button2Children: '\u25A1',
+				button3Children: '\u02DF' },
 			_react2.default.createElement(
 				'div',
 				{ style: {

--- a/modules/DnR.jsx
+++ b/modules/DnR.jsx
@@ -55,6 +55,9 @@ export default class DnR extends React.Component {
       cursor: 'auto',
       transition: prefixedTransition(transition ? transition : theme.transition)
     };
+
+    this.mouseMoveListener = this._onMove.bind(this)
+    this.mouseUpListener = this._onUp.bind(this)
   }
   componentDidMount() {
     const {
@@ -71,8 +74,8 @@ export default class DnR extends React.Component {
     this.frameRect.top = initialTop || this.refs.frame.offsetTop
     this.frameRect.left = initialLeft || this.refs.frame.offsetLeft
 
-    this.mouseMoveListener = attachedTo.addEventListener('mousemove', this._onMove.bind(this))
-    this.mouseUpListener = attachedTo.addEventListener('mouseup', this._onUp.bind(this))
+    attachedTo.addEventListener('mousemove', this.mouseMoveListener)
+    attachedTo.addEventListener('mouseup', this.mouseUpListener)
   }
   componentWillReceiveProps(nextProps) {
     if (nextProps.transition !== this.props.transition){
@@ -81,7 +84,7 @@ export default class DnR extends React.Component {
   }
   componentWillUnmount() {
     this.props.attachedTo.removeEventListener('mousemove', this.mouseMoveListener)
-    this.props.attachedTo.removeEventListener('mousemove', this.mouseUpListener)
+    this.props.attachedTo.removeEventListener('mouseup', this.mouseUpListener)
   }
   transform(state, allowTransition = true, updateHistory = true) {
     const boundingBox = this.getFrameRect()


### PR DESCRIPTION
There was a typo in `componentWillUnmount` function when calling `removeEventListener`.  Also, `addEventListener` does not return a value, one should use named functions.  A common practice is to bind a context for event handlers in the constructor.

Most of the changes were done by build tool `npm run build`, I only modified few lines in `modules/DnR.jsx`.
